### PR TITLE
Progressbar

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -9,6 +9,7 @@ use crate::{
         countdown::{Countdown, CountdownWidget},
         footer::Footer,
         pomodoro::{Mode as PomodoroMode, Pomodoro, PomodoroArgs, PomodoroWidget},
+        progressbar::Progressbar,
         timer::{Timer, TimerWidget},
     },
 };
@@ -173,11 +174,19 @@ impl App {
         }
     }
 
-    fn clock_is_running(&mut self) -> bool {
+    fn clock_is_running(&self) -> bool {
         match self.content {
-            Content::Countdown => self.countdown.get_clock().clone().is_running(),
-            Content::Timer => self.timer.get_clock().clone().is_running(),
+            Content::Countdown => self.countdown.get_clock().is_running(),
+            Content::Timer => self.timer.get_clock().is_running(),
             Content::Pomodoro => self.pomodoro.get_clock().is_running(),
+        }
+    }
+
+    fn get_percentage_done(&self) -> Option<u16> {
+        match self.content {
+            Content::Countdown => Some(self.countdown.get_clock().get_percentage_done()),
+            Content::Timer => None,
+            Content::Pomodoro => Some(self.pomodoro.get_clock().get_percentage_done()),
         }
     }
 
@@ -249,14 +258,20 @@ impl AppWidget {
 impl StatefulWidget for AppWidget {
     type State = App;
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
-        let [v0, v1] = Layout::vertical([
+        let [v0, v1, v2] = Layout::vertical([
+            Constraint::Length(1),
             Constraint::Percentage(100),
             Constraint::Length(if state.show_menu { 4 } else { 1 }),
         ])
         .areas(area);
 
+        // header
+        Progressbar {
+            percentage: state.get_percentage_done(),
+        }
+        .render(v0, buf);
         // content
-        self.render_content(v0, buf, state);
+        self.render_content(v1, buf, state);
         // footer
         Footer {
             show_menu: state.show_menu,
@@ -264,6 +279,6 @@ impl StatefulWidget for AppWidget {
             selected_content: state.content,
             edit_mode: state.is_edit_mode(),
         }
-        .render(v1, buf);
+        .render(v2, buf);
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,8 +8,8 @@ use crate::{
         clock::{self, Clock, ClockArgs, Style},
         countdown::{Countdown, CountdownWidget},
         footer::Footer,
+        header::Header,
         pomodoro::{Mode as PomodoroMode, Pomodoro, PomodoroArgs, PomodoroWidget},
-        progressbar::Progressbar,
         timer::{Timer, TimerWidget},
     },
 };
@@ -266,7 +266,7 @@ impl StatefulWidget for AppWidget {
         .areas(area);
 
         // header
-        Progressbar {
+        Header {
             percentage: state.get_percentage_done(),
         }
         .render(v0, buf);

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -2,4 +2,5 @@ pub mod clock;
 pub mod countdown;
 pub mod footer;
 pub mod pomodoro;
+pub mod progressbar;
 pub mod timer;

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -1,6 +1,7 @@
 pub mod clock;
 pub mod countdown;
 pub mod footer;
+pub mod header;
 pub mod pomodoro;
 pub mod progressbar;
 pub mod timer;

--- a/src/widgets/clock.rs
+++ b/src/widgets/clock.rs
@@ -393,10 +393,20 @@ impl Clock<Countdown> {
         }
     }
 
-    pub fn set_done(&mut self) {
+    fn set_done(&mut self) {
         if self.current_value.is_zero() {
             self.mode = Mode::Done;
         }
+    }
+
+    pub fn get_percentage_done(&self) -> u16 {
+        let initial = self.initial_value.as_millis();
+        let elapsed = self
+            .initial_value
+            .saturating_sub(self.current_value)
+            .as_millis();
+
+        (elapsed * 100 / initial) as u16
     }
 
     pub fn edit_next(&mut self) {

--- a/src/widgets/footer.rs
+++ b/src/widgets/footer.rs
@@ -36,7 +36,7 @@ impl Widget for Footer {
             .title(
                 format! {"[m]enu {:} ", if self.show_menu {scrollbar::VERTICAL.end} else {scrollbar::VERTICAL.begin}},
             )
-            .border_set(border::DOUBLE)
+            .border_set(border::PLAIN)
             .render(border_area, buf);
         // show menu
         if self.show_menu {

--- a/src/widgets/header.rs
+++ b/src/widgets/header.rs
@@ -1,4 +1,8 @@
-use ratatui::{buffer::Buffer, layout::Rect, symbols::line, text::Span, widgets::Widget};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    widgets::{Block, Borders, Widget},
+};
 
 use crate::widgets::progressbar::Progressbar;
 
@@ -12,8 +16,7 @@ impl Widget for Header {
         if let Some(percentage) = self.percentage {
             Progressbar::new(percentage).render(area, buf);
         } else {
-            // done
-            Span::from(line::HORIZONTAL.repeat(area.width as usize)).render(area, buf);
+            Block::new().borders(Borders::TOP).render(area, buf);
         }
     }
 }

--- a/src/widgets/header.rs
+++ b/src/widgets/header.rs
@@ -1,0 +1,19 @@
+use ratatui::{buffer::Buffer, layout::Rect, symbols::line, text::Span, widgets::Widget};
+
+use crate::widgets::progressbar::Progressbar;
+
+#[derive(Debug, Clone)]
+pub struct Header {
+    pub percentage: Option<u16>,
+}
+
+impl Widget for Header {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        if let Some(percentage) = self.percentage {
+            Progressbar::new(percentage).render(area, buf);
+        } else {
+            // done
+            Span::from(line::HORIZONTAL.repeat(area.width as usize)).render(area, buf);
+        }
+    }
+}

--- a/src/widgets/progressbar.rs
+++ b/src/widgets/progressbar.rs
@@ -1,0 +1,30 @@
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, Layout, Rect},
+    symbols::line,
+    text::Span,
+    widgets::Widget,
+};
+
+#[derive(Debug, Clone)]
+pub struct Progressbar {
+    pub percentage: Option<u16>,
+}
+
+impl Widget for Progressbar {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        if let Some(percentage) = self.percentage {
+            let [h0, h1] =
+                Layout::horizontal([Constraint::Percentage(percentage), Constraint::Fill(0)])
+                    .areas(area);
+
+            // done
+            Span::from(line::THICK_HORIZONTAL.repeat(h0.width as usize)).render(h0, buf);
+            // rest
+            Span::from(line::HORIZONTAL.repeat(h1.width as usize)).render(h1, buf);
+        } else {
+            // done
+            Span::from(line::HORIZONTAL.repeat(area.width as usize)).render(area, buf);
+        }
+    }
+}

--- a/src/widgets/progressbar.rs
+++ b/src/widgets/progressbar.rs
@@ -19,13 +19,21 @@ impl Progressbar {
 
 impl Widget for Progressbar {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let [h0, h1] =
+        let label = Span::raw(format!(" {}% ", self.percentage));
+        let [h0, area] = Layout::horizontal([
+            Constraint::Length(label.width() as u16),
+            Constraint::Percentage(100),
+        ])
+        .areas(area);
+        let [h1, h2] =
             Layout::horizontal([Constraint::Percentage(self.percentage), Constraint::Fill(0)])
                 .areas(area);
 
+        // label
+        label.render(h0, buf);
         // done
-        Span::from(line::THICK_HORIZONTAL.repeat(h0.width as usize)).render(h0, buf);
+        Span::from(line::THICK_HORIZONTAL.repeat(h1.width as usize)).render(h1, buf);
         // rest
-        Span::from(line::HORIZONTAL.repeat(h1.width as usize)).render(h1, buf);
+        Span::from(line::HORIZONTAL.repeat(h2.width as usize)).render(h2, buf);
     }
 }

--- a/src/widgets/progressbar.rs
+++ b/src/widgets/progressbar.rs
@@ -8,23 +8,24 @@ use ratatui::{
 
 #[derive(Debug, Clone)]
 pub struct Progressbar {
-    pub percentage: Option<u16>,
+    pub percentage: u16,
+}
+
+impl Progressbar {
+    pub fn new(percentage: u16) -> Self {
+        Self { percentage }
+    }
 }
 
 impl Widget for Progressbar {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        if let Some(percentage) = self.percentage {
-            let [h0, h1] =
-                Layout::horizontal([Constraint::Percentage(percentage), Constraint::Fill(0)])
-                    .areas(area);
+        let [h0, h1] =
+            Layout::horizontal([Constraint::Percentage(self.percentage), Constraint::Fill(0)])
+                .areas(area);
 
-            // done
-            Span::from(line::THICK_HORIZONTAL.repeat(h0.width as usize)).render(h0, buf);
-            // rest
-            Span::from(line::HORIZONTAL.repeat(h1.width as usize)).render(h1, buf);
-        } else {
-            // done
-            Span::from(line::HORIZONTAL.repeat(area.width as usize)).render(area, buf);
-        }
+        // done
+        Span::from(line::THICK_HORIZONTAL.repeat(h0.width as usize)).render(h0, buf);
+        // rest
+        Span::from(line::HORIZONTAL.repeat(h1.width as usize)).render(h1, buf);
     }
 }


### PR DESCRIPTION
Very light. It uses different symbols to render `filled`/`unfilled` lines. Note: `LineGauge` does not support that (yet).

Highlights status of `Clock<Countdown>` only. A `Clock<Timer>` won't never be done (unknown percentage). 

# On the top

![timr-progressbar](https://github.com/user-attachments/assets/8244b223-9d0c-4083-9004-fbb6f9578e04)
