### PR TITLE
fix: use `data_local_dir` if `state_dir` not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ Stored on file system.
 cat ~/.local/state/timr/data/timr.data
 ```
 
+- `macOS`
+```sh
+cat /Users/{user}/Library/Application Support/timr/data/timr.data
+```
+
+- `Windows`
+```sh
+cat C:/Users/{user}/AppData/Local/timr/data/timr.data
+```
+
 ## Logs
 
 In `debug` mode only.
@@ -133,4 +143,14 @@ In `debug` mode only.
 - `Linux`
 ```sh
 tail -f ~/.local/state/timr/logs/timr.log
+```
+
+- `macOS`
+```sh
+tail -f /Users/{user}/Library/Application Support/timr/logs/timr.log
+```
+
+- `Windows`
+```sh
+tail -f C:/Users/{user}/AppData/Local/timr/logs/timr.log
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,10 +27,11 @@ pub fn get_project_dir() -> Result<ProjectDirs> {
 }
 
 fn get_default_state_dir() -> Result<PathBuf> {
-    let directory = get_project_dir()?
+    let dirs = get_project_dir()?;
+    let directory: PathBuf = dirs
         .state_dir()
-        .map(|d| d.to_path_buf())
-        .ok_or_else(|| eyre!("Failed to get state directory"))?;
+        .unwrap_or_else(|| dirs.data_local_dir())
+        .to_path_buf();
 
     Ok(directory)
 }


### PR DESCRIPTION
Fixes #30