### PR TITLE
feat(cli): arg `--menu`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ Options:
   -p, --pause <PAUSE>          Pause time to count down from. Formats: 'ss', 'mm:ss', or 'hh:mm:ss' [default: 5:00]
   -d, --decis                  Wether to show deciseconds or not. [default: false]
   -m, --mode <MODE>            Mode to start with. [possible values: countdown, timer, pomodoro] [default: timer]
+      --menu                   Whether to open the menu or not.
   -s, --style <STYLE>          Style to display time with. [possible values: full, light, medium, dark, thick, cross, braille] [default: full]
   -r, --reset                  Reset stored values to default.
   -h, --help                   Print help
+  -V, --version                Print version
 ```
 
 # Build from source 🔧

--- a/src/app.rs
+++ b/src/app.rs
@@ -63,7 +63,7 @@ impl From<(Args, AppStorage)> for AppArgs {
     fn from((args, stg): (Args, AppStorage)) -> Self {
         AppArgs {
             with_decis: args.decis || stg.with_decis,
-            show_menu: stg.show_menu,
+            show_menu: args.menu || stg.show_menu,
             content: args.mode.unwrap_or(stg.content),
             style: args.style.unwrap_or(stg.style),
             pomodoro_mode: stg.pomodoro_mode,

--- a/src/args.rs
+++ b/src/args.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use crate::common::{Content, Style};
 
 #[derive(Parser)]
+#[command(version)]
 pub struct Args {
     #[arg(long, short, value_parser = parse_duration,
         help = "Countdown time to start from. Formats: 'ss', 'mm:ss', or 'hh:mm:ss'"
@@ -32,6 +33,9 @@ pub struct Args {
 
     #[arg(long, short = 's', value_enum, help = "Style to display time with.")]
     pub style: Option<Style>,
+
+    #[arg(long, value_enum, help = "Whether to open the menu or not.")]
+    pub menu: bool,
 
     #[arg(long, short = 'r', help = "Reset stored values to default.")]
     pub reset: bool,

--- a/src/common.rs
+++ b/src/common.rs
@@ -30,9 +30,9 @@ pub enum Style {
     Thick,
     #[value(name = "cross", alias = "c")]
     Cross,
-    /// https://en.wikipedia.org/wiki/Braille_Patterns
-    /// Note: Might not be supported in all terminals
-    /// see https://docs.rs/ratatui/latest/src/ratatui/symbols.rs.html#150
+    // https://en.wikipedia.org/wiki/Braille_Patterns
+    // Note: Might not be supported in all terminals
+    // see https://docs.rs/ratatui/latest/src/ratatui/symbols.rs.html#150
     #[value(name = "braille", alias = "b")]
     Braille,
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -36,7 +36,7 @@ impl Default for AppStorage {
         const DEFAULT_COUNTDOWN: Duration = Duration::from_secs(60 * 10); /* 10min */
         AppStorage {
             content: Content::default(),
-            show_menu: false,
+            show_menu: true,
             style: Style::default(),
             with_decis: false,
             pomodoro_mode: PomodoroMode::Work,


### PR DESCRIPTION
- Add `--menu` to args
- Add `--version` to args
- Change default behavior: At a first run of the app, the menu will be shown by default (similar to what @tschinz suggested in #33). However, if an user hides the menu later and closes the app, the menu will be hidden again with a next start. Just because the app restores the last app state.
